### PR TITLE
feat: add iTerm2 tab-level focus restoration on notification click

### DIFF
--- a/cc_notifier.context.md
+++ b/cc_notifier.context.md
@@ -45,7 +45,8 @@ Flows are in the order they are executed, and are performed synchronously, unles
    - If window ID is "UNAVAILABLE": send unconditional notification without click-to-focus
    - Otherwise: Get current focused window ID via Hammerspoon CLI
    - Compare original vs current window ID
-     - Same window: Don't send local notification, continue to push check
+     - Same window + same iTerm2 tab (or no tab ID): Don't send local notification, continue to push check
+     - Same window + different iTerm2 tab: Send local notification with click-to-focus and tab selection
      - Different window: Send local notification via terminal-notifier with click-to-focus (includes iTerm2 tab selection if tab ID was captured)
    - Local notification failures are caught so push notifications still fire
    - Update session timestamp

--- a/cc_notifier.context.md
+++ b/cc_notifier.context.md
@@ -14,6 +14,7 @@ Primarily a high-level architectural reference, not a detailed implementation gu
 
 - **Session Files**: `/tmp/cc_notifier/{session_id}` containing window ID, app path, and timestamp
 - **Window Management**: Hammerspoon CLI for cross-space window focusing
+- **Tab Management**: iTerm2 AppleScript for tab-level focus restoration (captures session UUID during init, selects tab on click)
 - **Local Notifications**: terminal-notifier with `-execute` parameter for click actions
 - **Push Notifications**: Pushover API integration
 
@@ -29,8 +30,9 @@ Flows are in the order they are executed, and are performed synchronously, unles
 2. **Desktop Mode**: Get focused window ID via Hammerspoon CLI (`hs.window.focusedWindow()`)
    **Remote Mode**: Use placeholder "REMOTE" (auto-detected via SSH environment variables)
    **Hammerspoon Missing**: Falls back to "UNAVAILABLE" placeholder (graceful degradation)
-3. Save window ID, app path, and timestamp to `/tmp/cc_notifier/{session_id}`
-4. Exit immediately
+3. **iTerm2 Tab Capture**: If focused app is iTerm2, capture session ID via AppleScript for tab-level focus restoration
+4. Save window ID, app path, timestamp, and optional tab ID to `/tmp/cc_notifier/{session_id}`
+5. Exit immediately
 
 ### `cc-notifier notify`
 **Trigger**: Claude Code Stop/Notification hooks (Stop: Runs when the main Claude Code agent has finished responding. Notification: Runs when Claude needs user attention - permission prompts, idle timeouts, auth events, and other notification types)
@@ -44,7 +46,7 @@ Flows are in the order they are executed, and are performed synchronously, unles
    - Otherwise: Get current focused window ID via Hammerspoon CLI
    - Compare original vs current window ID
      - Same window: Don't send local notification, continue to push check
-     - Different window: Send local notification via terminal-notifier with click-to-focus
+     - Different window: Send local notification via terminal-notifier with click-to-focus (includes iTerm2 tab selection if tab ID was captured)
    - Local notification failures are caught so push notifications still fire
    - Update session timestamp
 5. **Remote Mode Only**: Skip local notifications entirely
@@ -98,6 +100,7 @@ Note: Claude Code sends additional fields (e.g., `transcript_path`) that are fil
   <window_id>
   <app_path>
   <unix_timestamp>
+  <tab_id>           (optional, iTerm2 session UUID for tab-level focus)
   ```
 
 **Log Files**

--- a/cc_notifier.py
+++ b/cc_notifier.py
@@ -244,6 +244,22 @@ def send_local_notification_if_needed(
     current_window_id, _ = get_focused_window_id()
 
     if original_window_id == current_window_id:
+        # Same window, but check if user is on a different iTerm2 tab
+        if tab_id:
+            current_tab_id = get_iterm2_session_id()
+            if current_tab_id and current_tab_id != tab_id:
+                debug_log(
+                    f"Same window but different tab: original={tab_id}, current={current_tab_id}"
+                )
+                title, subtitle, message = create_notification_data(hook_data)
+                send_notification(
+                    title=title,
+                    subtitle=subtitle,
+                    message=message,
+                    focus_window_id=original_window_id,
+                    tab_id=tab_id,
+                )
+                return
         debug_log("User still on original window - no local notification needed")
         return
 

--- a/cc_notifier.py
+++ b/cc_notifier.py
@@ -100,6 +100,7 @@ def main() -> None:
 def cmd_init() -> None:
     """Initialize session by capturing focused window ID and app path."""
     hook_data = HookData.from_stdin()
+    tab_id = ""
     if is_remote_session():
         window_id, app_path = "REMOTE", "REMOTE"
         debug_log("Remote session detected, skipping window capture")
@@ -109,7 +110,9 @@ def cmd_init() -> None:
         except (RuntimeError, OSError) as e:
             window_id, app_path = "UNAVAILABLE", "UNAVAILABLE"
             debug_log(f"Window capture failed, continuing without: {e}")
-    save_window_id(hook_data.session_id, window_id, app_path)
+        if app_path.endswith("/iTerm.app"):
+            tab_id = get_iterm2_session_id()
+    save_window_id(hook_data.session_id, window_id, app_path, tab_id=tab_id)
 
 
 @handle_command_errors("notify")
@@ -125,6 +128,8 @@ def cmd_notify() -> None:
     lines = session_file.read_text().strip().split("\n")
     original_window_id = lines[0]
     app_path = lines[1]
+    # Tab ID is optional (4th line, index 3) for backward compatibility
+    tab_id = lines[3] if len(lines) > 3 else ""
 
     # Set global app path for error handling
     _CURRENT_APP_PATH = app_path
@@ -132,7 +137,9 @@ def cmd_notify() -> None:
     # Local notifications only in desktop mode
     if not is_remote_session():
         try:
-            send_local_notification_if_needed(hook_data, original_window_id)
+            send_local_notification_if_needed(
+                hook_data, original_window_id, tab_id=tab_id
+            )
         except (RuntimeError, OSError) as e:
             log_error("Local notification failed, continuing to push", e)
 
@@ -208,14 +215,15 @@ def check_deduplication(session_file: Path) -> bool:
         with open(session_file, "r+") as f:
             fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             lines = f.read().strip().split("\n")
-            # Lines: [0]=window_id, [1]=app_name, [2]=timestamp
+            # Lines: [0]=window_id, [1]=app_name, [2]=timestamp, [3]=tab_id (optional)
             if (
                 time.time() - float(lines[2])
                 < NOTIFICATION_DEDUPLICATION_THRESHOLD_SECONDS
             ):
                 return True
+            tab_id = lines[3] if len(lines) > 3 else ""
             f.seek(0)
-            f.write(f"{lines[0]}\n{lines[1]}\n{time.time()}")
+            f.write(f"{lines[0]}\n{lines[1]}\n{time.time()}\n{tab_id}")
             f.truncate()
             return False
     except BlockingIOError:
@@ -223,7 +231,7 @@ def check_deduplication(session_file: Path) -> bool:
 
 
 def send_local_notification_if_needed(
-    hook_data: HookData, original_window_id: str
+    hook_data: HookData, original_window_id: str, tab_id: str = ""
 ) -> None:
     """Send local notification if user switched away from original window."""
     # Without Hammerspoon, always send notification (no window comparison possible)
@@ -243,7 +251,7 @@ def send_local_notification_if_needed(
     title, subtitle, message = create_notification_data(hook_data)
 
     debug_log(
-        f"Sending local notification: original_window={original_window_id}, current_window={current_window_id}, notification='{title}' | '{subtitle}' | '{message}'"
+        f"Sending local notification: original_window={original_window_id}, current_window={current_window_id}, tab_id={tab_id}, notification='{title}' | '{subtitle}' | '{message}'"
     )
 
     send_notification(
@@ -251,16 +259,19 @@ def send_local_notification_if_needed(
         subtitle=subtitle,
         message=message,
         focus_window_id=original_window_id,
+        tab_id=tab_id,
     )
 
 
-def save_window_id(session_id: str, window_id: str, app_path: str) -> None:
-    """Save window ID and app path to session file."""
+def save_window_id(
+    session_id: str, window_id: str, app_path: str, tab_id: str = ""
+) -> None:
+    """Save window ID, app path, and optional tab ID to session file."""
     SESSION_DIR.mkdir(exist_ok=True)
     session_file = SESSION_DIR / session_id
-    session_file.write_text(f"{window_id}\n{app_path}\n0")
+    session_file.write_text(f"{window_id}\n{app_path}\n0\n{tab_id}")
     debug_log(
-        f"Session initialized: window_id={window_id}, app_path={app_path}, session_file={session_file}"
+        f"Session initialized: window_id={window_id}, app_path={app_path}, tab_id={tab_id}, session_file={session_file}"
     )
 
 
@@ -451,6 +462,49 @@ require('hs.notify').new({{title="cc-notifier", informativeText="Could not resto
 
 
 # ============================================================================
+# ITERM2 INTEGRATION - Tab-Level Focus Restoration
+# ============================================================================
+
+
+def get_iterm2_session_id() -> str:
+    """Get the current iTerm2 session ID for tab-level focus restoration.
+
+    Returns the session UUID or empty string on failure.
+    """
+    try:
+        output = run_command(
+            [
+                "osascript",
+                "-e",
+                'tell application "iTerm2" to get id of current session of current tab of current window',
+            ],
+            timeout=3,
+        )
+        debug_log(f"iTerm2 session ID captured: {output}")
+        return output
+    except (RuntimeError, subprocess.TimeoutExpired) as e:
+        debug_log(f"iTerm2 session ID capture failed: {e}")
+        return ""
+
+
+def create_iterm2_tab_select_command(session_id: str) -> list[str]:
+    """Create an AppleScript command to select the iTerm2 tab containing the given session ID."""
+    script = f"""tell application "iTerm2"
+  repeat with w in windows
+    repeat with t in tabs of w
+      repeat with s in sessions of t
+        if id of s is "{session_id}" then
+          tell t to select
+          return
+        end if
+      end repeat
+    end repeat
+  end repeat
+end tell"""
+    return ["osascript", "-e", script]
+
+
+# ============================================================================
 # NOTIFICATION SYSTEM - macOS Notifications with Click-to-Focus
 # ============================================================================
 
@@ -549,7 +603,11 @@ def create_notification_data(
 
 
 def send_notification(
-    title: str, subtitle: str, message: str, focus_window_id: Optional[str] = None
+    title: str,
+    subtitle: str,
+    message: str,
+    focus_window_id: Optional[str] = None,
+    tab_id: str = "",
 ) -> None:
     """Send a macOS notification with optional click-to-focus functionality."""
     cmd = [
@@ -569,13 +627,20 @@ def send_notification(
     if focus_window_id:
         focus_cmd = create_focus_command(focus_window_id)
         execute_cmd = " ".join(shlex.quote(arg) for arg in focus_cmd)
+        # Chain iTerm2 tab selection after window focus
+        if tab_id:
+            tab_cmd = create_iterm2_tab_select_command(tab_id)
+            tab_cmd_str = " ".join(shlex.quote(arg) for arg in tab_cmd)
+            execute_cmd = f"{execute_cmd} && {tab_cmd_str}"
         cmd.extend(["-execute", execute_cmd])
 
     # Send notification in background
     try:
         run_background_command(cmd)
         if DEBUG:
-            debug_log(f"Notification sent: focus_window_id={focus_window_id}")
+            debug_log(
+                f"Notification sent: focus_window_id={focus_window_id}, tab_id={tab_id}"
+            )
     except Exception as e:
         debug_log(f"Notification failed: {type(e).__name__}")
         raise

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -109,7 +109,10 @@ class TestCLIInterface:
                 mock_stdin.assert_called_once()
                 mock_window.assert_called_once()
                 mock_save.assert_called_once_with(
-                    "test", "12345", "/System/Applications/Utilities/Terminal.app"
+                    "test",
+                    "12345",
+                    "/System/Applications/Utilities/Terminal.app",
+                    tab_id="",
                 )
 
         finally:
@@ -465,6 +468,153 @@ class TestCoreWorkflows:
             assert session_file.read_text() == old_content
 
 
+class TestITerm2TabFocus:
+    """Test iTerm2 tab-level focus restoration."""
+
+    def test_init_captures_iterm2_session_id(self, tmp_path):
+        """Test init captures iTerm2 session ID when app is iTerm."""
+        test_input = {"session_id": "iterm_test", "cwd": "/test"}
+        session_dir = tmp_path / "cc_notifier"
+
+        with (
+            patch(
+                "cc_notifier.get_focused_window_id",
+                return_value=("12345", "/Applications/iTerm.app"),
+            ),
+            patch(
+                "cc_notifier.get_iterm2_session_id",
+                return_value="ABC-123-DEF",
+            ) as mock_iterm,
+            patch("sys.stdin", StringIO(json.dumps(test_input))),
+            patch.object(sys, "argv", ["cc-notifier", "init"]),
+            patch.object(cc_notifier, "SESSION_DIR", session_dir),
+            patch.dict(os.environ, {"CC_NOTIFIER_WRAPPER": "1"}),
+        ):
+            cc_notifier.main()
+
+        mock_iterm.assert_called_once()
+        content = (session_dir / "iterm_test").read_text()
+        lines = content.split("\n")
+        assert lines[0] == "12345"
+        assert lines[1] == "/Applications/iTerm.app"
+        assert lines[3] == "ABC-123-DEF"
+
+    def test_init_skips_iterm2_for_other_apps(self, tmp_path):
+        """Test init does not query iTerm2 session for non-iTerm apps."""
+        test_input = {"session_id": "other_test", "cwd": "/test"}
+        session_dir = tmp_path / "cc_notifier"
+
+        with (
+            patch(
+                "cc_notifier.get_focused_window_id",
+                return_value=("12345", "/Applications/Visual Studio Code.app"),
+            ),
+            patch(
+                "cc_notifier.get_iterm2_session_id",
+            ) as mock_iterm,
+            patch("sys.stdin", StringIO(json.dumps(test_input))),
+            patch.object(sys, "argv", ["cc-notifier", "init"]),
+            patch.object(cc_notifier, "SESSION_DIR", session_dir),
+            patch.dict(os.environ, {"CC_NOTIFIER_WRAPPER": "1"}),
+        ):
+            cc_notifier.main()
+
+        mock_iterm.assert_not_called()
+        content = (session_dir / "other_test").read_text()
+        lines = content.split("\n")
+        assert lines[3] == ""  # No tab ID
+
+    def test_notify_includes_tab_select_in_focus_command(self, tmp_path):
+        """Test notify chains iTerm2 tab select after window focus."""
+        test_input = {"session_id": "tab_test", "cwd": "/test/project"}
+        session_dir = tmp_path / "cc_notifier"
+        session_dir.mkdir()
+        (session_dir / "tab_test").write_text(
+            "original123\n/Applications/iTerm.app\n0\nABC-123-DEF"
+        )
+
+        env = {"CC_NOTIFIER_WRAPPER": "1", "CC_NOTIFIER_TITLE_FORMAT": ""}
+
+        with (
+            patch(
+                "cc_notifier.get_focused_window_id",
+                return_value=("different456", "/Applications/Google Chrome.app"),
+            ),
+            patch("subprocess.Popen") as mock_popen,
+            patch("sys.stdin", StringIO(json.dumps(test_input))),
+            patch.object(sys, "argv", ["cc-notifier", "notify"]),
+            patch.object(cc_notifier, "SESSION_DIR", session_dir),
+            patch("cc_notifier.check_idle_and_notify_push"),
+            patch.dict(os.environ, env),
+        ):
+            cc_notifier.main()
+
+        # Find the terminal-notifier call
+        popen_calls = [call[0][0] for call in mock_popen.call_args_list]
+        terminal_notifier_calls = [
+            cmd
+            for cmd in popen_calls
+            if any("terminal-notifier" in str(arg) for arg in cmd)
+        ]
+        assert len(terminal_notifier_calls) >= 1
+
+        # Verify -execute contains both window focus and tab select
+        cmd = terminal_notifier_calls[0]
+        execute_idx = cmd.index("-execute")
+        execute_cmd = cmd[execute_idx + 1]
+        assert "&&" in execute_cmd
+        assert "osascript" in execute_cmd
+        assert "ABC-123-DEF" in execute_cmd
+
+    def test_notify_no_tab_select_without_tab_id(self, tmp_path):
+        """Test notify does not add tab select when no tab ID stored."""
+        test_input = {"session_id": "notab_test", "cwd": "/test/project"}
+        session_dir = tmp_path / "cc_notifier"
+        session_dir.mkdir()
+        # Session file without tab ID (backward compatible)
+        (session_dir / "notab_test").write_text(
+            "original123\n/System/Applications/Utilities/Terminal.app\n0"
+        )
+
+        env = {"CC_NOTIFIER_WRAPPER": "1", "CC_NOTIFIER_TITLE_FORMAT": ""}
+
+        with (
+            patch(
+                "cc_notifier.get_focused_window_id",
+                return_value=("different456", "/Applications/Google Chrome.app"),
+            ),
+            patch("subprocess.Popen") as mock_popen,
+            patch("sys.stdin", StringIO(json.dumps(test_input))),
+            patch.object(sys, "argv", ["cc-notifier", "notify"]),
+            patch.object(cc_notifier, "SESSION_DIR", session_dir),
+            patch("cc_notifier.check_idle_and_notify_push"),
+            patch.dict(os.environ, env),
+        ):
+            cc_notifier.main()
+
+        popen_calls = [call[0][0] for call in mock_popen.call_args_list]
+        terminal_notifier_calls = [
+            cmd
+            for cmd in popen_calls
+            if any("terminal-notifier" in str(arg) for arg in cmd)
+        ]
+        assert len(terminal_notifier_calls) >= 1
+
+        cmd = terminal_notifier_calls[0]
+        execute_idx = cmd.index("-execute")
+        execute_cmd = cmd[execute_idx + 1]
+        # No tab select chained
+        assert "&&" not in execute_cmd
+
+    def test_create_iterm2_tab_select_command(self):
+        """Test AppleScript command generation for tab selection."""
+        cmd = cc_notifier.create_iterm2_tab_select_command("ABC-123-DEF")
+        assert cmd[0] == "osascript"
+        assert cmd[1] == "-e"
+        assert "ABC-123-DEF" in cmd[2]
+        assert "tell t to select" in cmd[2]
+
+
 class TestDataParsing:
     """Test HookData dataclass parsing and validation."""
 
@@ -542,7 +692,7 @@ class TestSessionFileOperations:
             assert session_file.exists()
             assert (
                 session_file.read_text()
-                == "12345\n/System/Applications/Utilities/Terminal.app\n0"
+                == "12345\n/System/Applications/Utilities/Terminal.app\n0\n"
             )
 
     def test_load_window_id_reads_saved_id(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -606,6 +606,89 @@ class TestITerm2TabFocus:
         # No tab select chained
         assert "&&" not in execute_cmd
 
+    def test_notify_sends_when_same_window_different_tab(self, tmp_path):
+        """Test notify sends notification when same iTerm2 window but different tab."""
+        test_input = {"session_id": "difftab_test", "cwd": "/test/project"}
+        session_dir = tmp_path / "cc_notifier"
+        session_dir.mkdir()
+        (session_dir / "difftab_test").write_text(
+            "original123\n/Applications/iTerm.app\n0\nTAB-ORIGINAL"
+        )
+
+        env = {"CC_NOTIFIER_WRAPPER": "1", "CC_NOTIFIER_TITLE_FORMAT": ""}
+
+        with (
+            patch(
+                "cc_notifier.get_focused_window_id",
+                return_value=("original123", "/Applications/iTerm.app"),
+            ),
+            patch(
+                "cc_notifier.get_iterm2_session_id",
+                return_value="TAB-DIFFERENT",
+            ),
+            patch("subprocess.Popen") as mock_popen,
+            patch("sys.stdin", StringIO(json.dumps(test_input))),
+            patch.object(sys, "argv", ["cc-notifier", "notify"]),
+            patch.object(cc_notifier, "SESSION_DIR", session_dir),
+            patch("cc_notifier.check_idle_and_notify_push"),
+            patch.dict(os.environ, env),
+        ):
+            cc_notifier.main()
+
+        # Notification should have been sent despite same window ID
+        popen_calls = [call[0][0] for call in mock_popen.call_args_list]
+        terminal_notifier_calls = [
+            cmd
+            for cmd in popen_calls
+            if any("terminal-notifier" in str(arg) for arg in cmd)
+        ]
+        assert len(terminal_notifier_calls) >= 1
+
+        # Should include tab select in the execute command
+        cmd = terminal_notifier_calls[0]
+        execute_idx = cmd.index("-execute")
+        execute_cmd = cmd[execute_idx + 1]
+        assert "TAB-ORIGINAL" in execute_cmd
+
+    def test_notify_silent_when_same_window_same_tab(self, tmp_path):
+        """Test notify stays silent when same iTerm2 window and same tab."""
+        test_input = {"session_id": "sametab_test", "cwd": "/test/project"}
+        session_dir = tmp_path / "cc_notifier"
+        session_dir.mkdir()
+        (session_dir / "sametab_test").write_text(
+            "original123\n/Applications/iTerm.app\n0\nTAB-SAME"
+        )
+
+        env = {"CC_NOTIFIER_WRAPPER": "1", "CC_NOTIFIER_TITLE_FORMAT": ""}
+
+        with (
+            patch(
+                "cc_notifier.get_focused_window_id",
+                return_value=("original123", "/Applications/iTerm.app"),
+            ),
+            patch(
+                "cc_notifier.get_iterm2_session_id",
+                return_value="TAB-SAME",
+            ),
+            patch("subprocess.Popen") as mock_popen,
+            patch("sys.stdin", StringIO(json.dumps(test_input))),
+            patch.object(sys, "argv", ["cc-notifier", "notify"]),
+            patch.object(cc_notifier, "SESSION_DIR", session_dir),
+            patch("cc_notifier.check_idle_and_notify_push"),
+            patch.dict(os.environ, env),
+        ):
+            cc_notifier.main()
+
+        # No notification should be sent
+        if mock_popen.called:
+            popen_calls = [call[0][0] for call in mock_popen.call_args_list]
+            terminal_notifier_calls = [
+                cmd
+                for cmd in popen_calls
+                if any("terminal-notifier" in str(arg) for arg in cmd)
+            ]
+            assert len(terminal_notifier_calls) == 0
+
     def test_create_iterm2_tab_select_command(self):
         """Test AppleScript command generation for tab selection."""
         cmd = cc_notifier.create_iterm2_tab_select_command("ABC-123-DEF")

--- a/tests/tests.context.md
+++ b/tests/tests.context.md
@@ -8,13 +8,13 @@ Associated with: all tests in the codebase
 
 **Format**: `test_name` - [concise description of what's being tested] - [rationale for why test is needed]
 
-**Status**: **54 total tests** across 2 files - All tests properly accounted for and documented
+**Status**: **59 total tests** across 2 files - All tests properly accounted for and documented
 
 **Structure**: Tests are organized by functionality and concerns, emphasizing behavior-focused testing over implementation details. The 2-file structure matches the natural architectural boundary between core logic and external system integration.
 
 ---
 
-## test_core.py (48 tests) - Core Functionality & Essential Business Logic
+## test_core.py (53 tests) - Core Functionality & Essential Business Logic
 
 ### TestCLIInterface (9 tests) - Essential CLI Contract Testing
 - `test_main_with_no_args_exits_with_error` - CLI error handling when no command provided - CLI must provide helpful usage info and exit gracefully
@@ -47,6 +47,13 @@ Associated with: all tests in the codebase
 - `test_save_window_id_creates_file` - Session file creation with window ID and timestamp - Essential for window focus restoration functionality
 - `test_load_window_id_reads_saved_id` - Session file reading and window ID extraction - Required for determining original window to focus
 - `test_load_window_id_missing_file_raises_error` - Error handling when session file doesn't exist - Prevents undefined behavior when files are missing
+
+### TestITerm2TabFocus (5 tests) - iTerm2 Tab-Level Focus Restoration
+- `test_init_captures_iterm2_session_id` - Init captures iTerm2 session UUID when app is iTerm - Essential for tab-level focus restoration
+- `test_init_skips_iterm2_for_other_apps` - Init skips iTerm2 query for non-iTerm apps - Prevents unnecessary AppleScript calls
+- `test_notify_includes_tab_select_in_focus_command` - Notify chains tab selection after window focus - Validates complete focus restoration with tab
+- `test_notify_no_tab_select_without_tab_id` - Notify omits tab selection when no tab ID - Backward compatibility with sessions lacking tab ID
+- `test_create_iterm2_tab_select_command` - AppleScript command generation for tab selection - Validates correct command structure
 
 ### TestRemoteMode (5 tests) - Remote SSH Session Testing
 - `test_remote_session_detection` - SSH environment variable detection for remote mode - Essential for determining desktop vs remote mode behavior

--- a/tests/tests.context.md
+++ b/tests/tests.context.md
@@ -8,13 +8,13 @@ Associated with: all tests in the codebase
 
 **Format**: `test_name` - [concise description of what's being tested] - [rationale for why test is needed]
 
-**Status**: **59 total tests** across 2 files - All tests properly accounted for and documented
+**Status**: **61 total tests** across 2 files - All tests properly accounted for and documented
 
 **Structure**: Tests are organized by functionality and concerns, emphasizing behavior-focused testing over implementation details. The 2-file structure matches the natural architectural boundary between core logic and external system integration.
 
 ---
 
-## test_core.py (53 tests) - Core Functionality & Essential Business Logic
+## test_core.py (55 tests) - Core Functionality & Essential Business Logic
 
 ### TestCLIInterface (9 tests) - Essential CLI Contract Testing
 - `test_main_with_no_args_exits_with_error` - CLI error handling when no command provided - CLI must provide helpful usage info and exit gracefully
@@ -48,11 +48,13 @@ Associated with: all tests in the codebase
 - `test_load_window_id_reads_saved_id` - Session file reading and window ID extraction - Required for determining original window to focus
 - `test_load_window_id_missing_file_raises_error` - Error handling when session file doesn't exist - Prevents undefined behavior when files are missing
 
-### TestITerm2TabFocus (5 tests) - iTerm2 Tab-Level Focus Restoration
+### TestITerm2TabFocus (7 tests) - iTerm2 Tab-Level Focus Restoration
 - `test_init_captures_iterm2_session_id` - Init captures iTerm2 session UUID when app is iTerm - Essential for tab-level focus restoration
 - `test_init_skips_iterm2_for_other_apps` - Init skips iTerm2 query for non-iTerm apps - Prevents unnecessary AppleScript calls
 - `test_notify_includes_tab_select_in_focus_command` - Notify chains tab selection after window focus - Validates complete focus restoration with tab
 - `test_notify_no_tab_select_without_tab_id` - Notify omits tab selection when no tab ID - Backward compatibility with sessions lacking tab ID
+- `test_notify_sends_when_same_window_different_tab` - Notify fires when same iTerm2 window but different tab - Core use case for multi-tab notification
+- `test_notify_silent_when_same_window_same_tab` - Notify stays silent when same window and same tab - Prevents unnecessary notifications
 - `test_create_iterm2_tab_select_command` - AppleScript command generation for tab selection - Validates correct command structure
 
 ### TestRemoteMode (5 tests) - Remote SSH Session Testing


### PR DESCRIPTION
## Summary
- Captures iTerm2 session UUID during `init` when the focused app is iTerm2
- On notification click, chains an AppleScript tab-select command after the Hammerspoon window focus, restoring the exact tab
- Detects when the user is on the same iTerm2 window but a different tab and still sends a notification
- Backward compatible: old session files without a tab ID continue to work
- 7 new tests covering tab capture, tab restore, same-window-different-tab detection, and backward compatibility

## How it works
1. **Init**: If the focused app is iTerm2 (`/Applications/iTerm.app`), queries the current session UUID via AppleScript and stores it as an optional 4th line in the session file
2. **Notify (window comparison)**: When the Hammerspoon window ID matches (same window), checks if the current iTerm2 session UUID differs from the saved one. If so, sends a notification
3. **Notify (click-to-focus)**: The `-execute` command for terminal-notifier chains both: `hs -c <focus_script> && osascript -e <tab_select_script>`

## Test plan
- [x] All 61 tests pass (`make check` green)
- [x] Verified notification fires when switching to a different app/window
- [x] Verified notification fires when on same iTerm2 window but different tab
- [x] Verified clicking notification restores correct window AND tab
- [x] Verified no notification when staying on same window and same tab
- [x] Verified backward compatibility with session files lacking tab ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)