### PR TITLE
ci: skip Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,13 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip PRs from forks. GitHub withholds secrets and the OIDC token from
+    # fork-triggered `pull_request` runs (security by design), so this action
+    # can't authenticate and the check fails through no fault of the contributor.
+    # To review a fork PR on demand, comment "@claude review the changes" on it:
+    # that fires claude.yml via issue_comment, which runs in this repo's context
+    # with secrets + OIDC available.
+    if: github.event.pull_request.head.repo.fork == false
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

The **Claude Code Review** check fails on every PR from a fork (e.g. #13) with:

```
error: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Could not fetch an OIDC token. Did you remember to add `id-token: write`...
```

This is **not** a missing-permission bug (the workflow already requests `id-token: write`) and **not** the contributor's fault. GitHub deliberately withholds repository secrets and the OIDC token from fork-triggered `pull_request` runs as a security measure, so `anthropics/claude-code-action` can't authenticate and fails before it reads the diff. Same-repo PRs are unaffected (they pass).

Confirmed against the run history: the two same-repo PRs succeeded; the one fork PR (#13) failed. See upstream [anthropics/claude-code-action#339](https://github.com/anthropics/claude-code-action/issues/339) (labeled `bug`/`p1`), [#542](https://github.com/anthropics/claude-code-action/issues/542), [#649](https://github.com/anthropics/claude-code-action/issues/649).

## Fix

Skip the `claude-review` job on fork PRs via `if: github.event.pull_request.head.repo.fork == false`. Fork PRs now show a neutral "skipped" check instead of a red ❌.

Fork PRs can still be reviewed **on demand** by commenting `@claude review the changes` on the PR — that fires `claude.yml`'s `issue_comment` trigger, which runs in the base-repo context where secrets and OIDC are available.

Considered but rejected: `pull_request_target` (would auto-review forks but runs with repo secrets against untrusted code — real prompt-injection / token-minting risk per upstream security guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)